### PR TITLE
resolving PR merge issues

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,10 +4,9 @@ const session = require('cookie-session');
 
 const PORT = process.env.PORT || 3000;
 const { SERVER_SESSION_SECRET, APS_APP_NAME, APS_CLIENT_ID, APS_CLIENT_SECRET, HOST_URL, CLI_CONFIG_PASSWORD, ALLOW_CONFIG_DOWNLOAD } = process.env;
-if (!SERVER_SESSION_SECRET || !APS_APP_NAME || !APS_CLIENT_ID || !APS_CLIENT_SECRET || !HOST_URL || !CLI_CONFIG_PASSWORD, ALLOW_CONFIG_DOWNLOAD) {
+if (!SERVER_SESSION_SECRET || !APS_APP_NAME || !APS_CLIENT_ID || !APS_CLIENT_SECRET || !HOST_URL || !CLI_CONFIG_PASSWORD || !ALLOW_CONFIG_DOWNLOAD) {
     console.error('Some of the following env. variables are missing:');
     console.error('SERVER_SESSION_SECRET, APS_APP_NAME, APS_CLIENT_ID, APS_CLIENT_SECRET, HOST_URL, CLI_CONFIG_PASSWORD, ALLOW_CONFIG_DOWNLOAD');
-
 
     console.error('missing env. variables set');
     return;


### PR DESCRIPTION
Setting the config file download for commandline utility to false by default to limit the direct download feature.